### PR TITLE
Add version info & bump version to 1.03

### DIFF
--- a/build_desktop.sh
+++ b/build_desktop.sh
@@ -4,6 +4,10 @@ set -euo pipefail
 BUILD_MAC=0
 BUILD_WIN=0
 
+# get app version from lib/version.lua
+appver=$(grep "^version_str =" lib/version.lua | cut -d '"' -f 2)
+[[ "$appver" =~ ^[0-9]\.[0-9][0-9]$ ]] || (echo "App version extraction failed: $appver is not x.xx. Aborting." && exit 1)
+
 options=$(getopt -l "win,mac,help" -o "w,m,h" -a -- "$@")
 eval set -- "$options"
 while true
@@ -45,7 +49,7 @@ if [[ $BUILD_WIN -eq 1 ]]; then
     echo "Packaging Windows exe..."
 
     WIN_FLOWIT_DIR="flowit-win"
-    WIN_FLOWIT_ZIP="$WIN_FLOWIT_DIR.zip"
+    WIN_FLOWIT_ZIP="${WIN_FLOWIT_DIR}-v${appver}.zip"
 
     WIN_LOVE_DIR="love-11.4-win32"
     WIN_LOVE_ZIP="$WIN_LOVE_DIR.zip"
@@ -86,7 +90,7 @@ if [[ $BUILD_MAC -eq 1 ]]; then
 
     MAC_LOVE_APP_DIR="love.app"
     MAC_FLOWIT_APP_DIR="Flowit.app"
-    MAC_FLOWIT_APP_ZIP="Flowit.app.zip"
+    MAC_FLOWIT_APP_ZIP="Flowit-mac-v${appver}.zip"
 
     MAC_LOVE_DIR="love-11.4-macos"
     MAC_LOVE_ZIP="$MAC_LOVE_DIR.zip"

--- a/flowit-vita/app_skeleton/index.lua
+++ b/flowit-vita/app_skeleton/index.lua
@@ -10,6 +10,7 @@ loadlib("controls_vita")
 
 -- globals
 loadlib("globals")
+loadlib("version")
 platform = PLATFORMS.VITA
 
 -- other libraries

--- a/flowit-vita/build.sh
+++ b/flowit-vita/build.sh
@@ -1,4 +1,5 @@
-#! /bin/bash
+#!/usr/bin/env bash
+set -euo pipefail
 
 make_pkg=true
 
@@ -20,6 +21,10 @@ done
 title="Flowit"
 appid="FLWT02021"
 
+# get app version from ../lib/version.lua
+appver=$(grep "^version_str =" ../lib/version.lua | cut -d '"' -f 2)
+[[ "$appver" =~ ^[0-9]\.[0-9][0-9]$ ]] || (echo "App version extraction failed: $appver is not x.xx. Aborting." && exit 1)
+
 # Copy app skeleton and lua libs to build folder
 echo "Copying build files"
 mkdir -p build
@@ -36,6 +41,6 @@ cp -r ../lib/!(*_desktop.lua|locale) build/assets/lib/
 if $make_pkg
 then
     # Make vita package
-    vita-mksfoex -s TITLE_ID="${appid}" "${title}" build/sce_sys/param.sfo
-    7z a -tzip "${title}.vpk" -r ./build/* ./build/eboot.bin
+    vita-mksfoex -s APP_VER="0${appver}" -s TITLE_ID="${appid}" "${title}" build/sce_sys/param.sfo
+    7z a -tzip "${title}_v${appver}.vpk" -r ./build/* ./build/eboot.bin
 fi

--- a/lib/settings_view.lua
+++ b/lib/settings_view.lua
@@ -19,7 +19,11 @@ VS.done_icon_size = 32
 
 VS.credits_x_buffer = 40
 VS.credits_font     = 18
-VS.credits_y        = 544 - 3*(VS.credits_font+3) - VS.screen_margin
+
+VS.credits_y        = 544 - 4*(VS.credits_font+3) - VS.screen_margin
+if platform ~= PLATFORMS.DESKTOP then
+    VS.credits_y        = 544 - 4*(VS.credits_font) - VS.screen_margin
+end
 
 VS.button_width     = 120
 VS.button_min_height = 48

--- a/lib/translation.lua
+++ b/lib/translation.lua
@@ -36,7 +36,7 @@ strings_i18n["en"] = {
     ["no"] = "No",
     ["yes"] = "Yes",
 
-    ["credits"] = "Flowit game by ByteHamster\nPorted by ywnico\ngithub.com/Flowit-Game",
+    ["credits"] = "Flowit game by ByteHamster\nPorted by ywnico\nVersion " .. version_str .. "\ngithub.com/Flowit-Game",
 }
 
 strings_i18n["ja"] = {
@@ -75,7 +75,7 @@ strings_i18n["ja"] = {
     ["no"] = "いいえ",
     ["yes"] = "はい",
 
-    ["credits"] = "Flowitゲームクリエイター：ByteHamster\nゲーム移植：ywnico\ngithub.com/Flowit-Game",
+    ["credits"] = "Flowitゲームクリエイター：ByteHamster\nゲーム移植：ywnico\nバージョン：" .. version_str .. "\ngithub.com/Flowit-Game",
 }
 
 strings_i18n["zh_t"] = {
@@ -114,7 +114,7 @@ strings_i18n["zh_t"] = {
     ["no"] = "否",
     ["yes"] = "是",
 
-    ["credits"] = "Flowit遊戲作者：ByteHamster\n軟體移植：ywnico\ngithub.com/Flowit-Game",
+    ["credits"] = "Flowit遊戲作者：ByteHamster\n軟體移植：ywnico\n版本：" .. version_str .. "\ngithub.com/Flowit-Game",
 }
 
 strings_i18n["zh_s"] = {
@@ -153,7 +153,7 @@ strings_i18n["zh_s"] = {
     ["no"] = "否",
     ["yes"] = "是",
 
-    ["credits"] = "Flowit游戏作者：ByteHamster\n软体移植：ywnico\ngithub.com/Flowit-Game",
+    ["credits"] = "Flowit游戏作者：ByteHamster\n软体移植：ywnico\n版本：" .. version_str .. "\ngithub.com/Flowit-Game",
 }
 
 function get_i18n(s)

--- a/lib/version.lua
+++ b/lib/version.lua
@@ -1,0 +1,2 @@
+-- Flowit-vita version (not the same as the version on the upstream Flowit  app for Android)
+version_str = "1.03"

--- a/main.lua
+++ b/main.lua
@@ -12,6 +12,7 @@ locale = require("lib/locale")
 
 -- globals
 loadlib("globals")
+loadlib("version")
 platform = PLATFORMS.DESKTOP
 
 -- other libraries


### PR DESCRIPTION
- Add version to settings view
- Add version to Vita vpk (so version can be viewed from the LiveArea)
- Add version to build scripts, so renaming outputs is unnecessary.
- Bump version to 1.03. (From now on we will follow x.xx naming, to
  comply with PS Vita requirements).