### PR TITLE
Bump levels and use fallback font for author when necessary

### DIFF
--- a/flowit-vita/app_skeleton/index.lua
+++ b/flowit-vita/app_skeleton/index.lua
@@ -65,6 +65,7 @@ end
 default_font_name = "good-times-rg.ttf"
 number_font_name = "good-times-rg.ttf"
 message_font_name = "LiberationSans-Regular.ttf" -- readable font for dialog text
+fallback_font_name = "SourceHanSansHW-VF.ttf" -- fallback for characters not in good-times-rg
 
 if (lang_code == "ja") or (lang_code == "ko") or (lang_code == "zh_t") or (lang_code == "zh_s") then
     default_font_name = "SourceHanSansHW-VF.ttf"

--- a/lib/game_drawing.lua
+++ b/lib/game_drawing.lua
@@ -351,7 +351,13 @@ function draw_info()
     end
 
     if (author ~= nil) then
-        draw_text(x_offset, 95 + y_offset, VG.font_author, author, "t", default_font_name)
+
+        local author_font_name = default_font_name
+        if (needsFallbackFont(author)) then
+            author_font_name = fallback_font_name
+        end
+
+        draw_text(x_offset, 95 + y_offset, VG.font_author, author, "t", author_font_name)
     end
 
     draw_text(x_offset, 115 + author_y_offset + y_offset, VG.font_small, get_i18n("moves:"), "t", default_font_name)

--- a/lib/util.lua
+++ b/lib/util.lua
@@ -42,3 +42,15 @@ end
 function round(n)
     return math.floor(n+0.5)
 end
+
+-- Given a string, return true if it should be rendered in the fallback font and
+-- false if it should be rendered in the default font (goodtimes).
+-- Goodtimes has < 400 characters, so we just check directly instead of using
+-- any font utils.
+function needsFallbackFont(str)
+    local non_goodtimes = "[^ !\"#$%%&'()*+,-./0123456789:;<=>?@ABCDEFGHIJKLMNOPQRSTUVWXYZ[\\%]^_`abcdefghijklmnopqrstuvwxyz{|}~ ¡¢£¥¦§¨©ª«®¯°±²³´¶·¸¹º»¼½¾¿ÀÁÂÃÄÅÆÇÈÉÊËÌÍÎÏÐÑÒÓÔÕÖ×ØÙÚÛÜÝÞßàáâãäåæçèéêëìíîïðñòóôõö÷øùúûüýþÿĀāĂăĄąĆćĊċČčĎďĐđĒēĔĕĖėĘęĚěĞğĠġĢģĦħĪīĬĭĮįİıĲĳĶķĹĺĻļĽľĿŀŁłŃńŅņŇňŊŋŌōŎŏŐőŒœŔŕŖŗŘřŚśŞşŠšŢţŤťŦŧŨũŪūŬŭŮůŰűŲųŴŵŶŷŸŹźŻżŽžȘșȚțˆˇ˘˙˚˛˜˝̦ẀẁẂẃẄẅỲỳ–—‘’‚“”„†‡•…‰‹›⁄⁰⁴⁵⁶⁷⁸⁹₀₁₂₃₄₅]"
+    if (string.match(str, non_goodtimes)) then
+        return true
+    end
+    return false
+end

--- a/lib/version.lua
+++ b/lib/version.lua
@@ -1,2 +1,2 @@
 -- Flowit-vita version (not the same as the version on the upstream Flowit  app for Android)
-version_str = "1.03"
+version_str = "1.04"

--- a/main.lua
+++ b/main.lua
@@ -62,6 +62,7 @@ end
 default_font_name = "good-times-rg.ttf"
 number_font_name = "good-times-rg.ttf"
 message_font_name = "LiberationSans-Regular.ttf" -- readable font for dialog text
+fallback_font_name = "SourceHanSansHW-VF.ttf" -- fallback for characters not in good-times-rg
 
 if (lang_code == "ja") or (lang_code == "ko") or (lang_code == "zh_t") or (lang_code == "zh_s") then
     default_font_name = "SourceHanSansHW-VF.ttf"


### PR DESCRIPTION
1. Update levels.
2. Check if the author name uses characters not in goodtimes font; if so, use the fallback font.
3. Bump version to 1.04.